### PR TITLE
Ignore IntelliJ-related files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Bazel build directories
 bazel-*/
 
-
+# IntelliJ Bazel Plugin Files.
 .ijwb/
+# IntelliJ primary project directory.
+.idea/


### PR DESCRIPTION
We don't want to check-in users' editor files, so we ignore the entire IntelliJ .idea directory.